### PR TITLE
Duration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ lint:
 
 .PHONY: test
 test:
-	cargo test
+	RUSTFLAGS='-Z macro-backtrace' cargo test
 
 .PHONY: bench
 bench:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -522,7 +522,7 @@ impl Duration {
     fn parse_days_time(bytes: &[u8], offset: usize) -> Result<Self, ParseError> {
         let (day, offset) = match bytes.get(offset).copied() {
             Some(c) => Self::parse_number(bytes, c, offset),
-            _ => return Err(ParseError::TooShort),
+            _ => Err(ParseError::TooShort),
         }?;
         let mut position = offset;
 

--- a/tests/main.rs
+++ b/tests/main.rs
@@ -371,6 +371,7 @@ param_tests! {
     duration_days_1day6: ok => "1DAYS", "P1D";
     duration_days_1day7: ok => "1d", "P1D";
     duration_days_1day8: ok => "1d ", "P1D";
+    duration_days_too_short: err => "x", DurationInvalidNumber;
     duration_days_invalid1: err => "1x", DurationInvalidDays;
     duration_days_invalid2: err => "1dx", TooShort;
     duration_days_invalid3: err => "1da", DurationInvalidDays;

--- a/tests/main.rs
+++ b/tests/main.rs
@@ -14,7 +14,7 @@ macro_rules! expect_ok_or_error {
             }
         }
     };
-    ($type:ty, $name:ident, error, $input:literal, $error:expr) => {
+    ($type:ty, $name:ident, err, $input:literal, $error:expr) => {
         paste::item! {
             #[allow(non_snake_case)]
             #[test]
@@ -30,9 +30,9 @@ macro_rules! expect_ok_or_error {
 
 /// macro to define many tests for expected values
 macro_rules! param_tests {
-    ($type:ty, $($name:ident: $ok_or_error:ident => $input:literal, $expected:expr;)*) => {
+    ($type:ty, $($name:ident: $ok_or_err:ident => $input:literal, $expected:expr;)*) => {
         $(
-            expect_ok_or_error!($type, $name, $ok_or_error, $input, $expected);
+            expect_ok_or_error!($type, $name, $ok_or_err, $input, $expected);
         )*
     }
 }
@@ -54,21 +54,21 @@ fn date() {
 
 param_tests! {
     Date,
-    date_short_3: error => "123", TooShort;
-    date_short_9: error => "2000:12:1", TooShort;
-    date: error => "xxxx:12:31", InvalidCharYear;
-    date_year_sep: error => "2020x12:13", InvalidCharDateSep;
-    date_mo_sep: error => "2020-12x13", InvalidCharDateSep;
-    date: error => "2020-13-01", OutOfRangeMonth;
-    date: error => "2020-04-31", OutOfRangeDay;
-    date_extra_space: error => "2020-04-01 ", ExtraCharacters;
-    date_extra_xxx: error => "2020-04-01xxx", ExtraCharacters;
+    date_short_3: err => "123", TooShort;
+    date_short_9: err => "2000:12:1", TooShort;
+    date: err => "xxxx:12:31", InvalidCharYear;
+    date_year_sep: err => "2020x12:13", InvalidCharDateSep;
+    date_mo_sep: err => "2020-12x13", InvalidCharDateSep;
+    date: err => "2020-13-01", OutOfRangeMonth;
+    date: err => "2020-04-31", OutOfRangeDay;
+    date_extra_space: err => "2020-04-01 ", ExtraCharacters;
+    date_extra_xxx: err => "2020-04-01xxx", ExtraCharacters;
     // leap year dates
     date_simple: ok => "2020-04-01", "2020-04-01";
     date_normal_not_leap: ok => "2003-02-28", "2003-02-28";
-    date_normal_not_leap: error => "2003-02-29", OutOfRangeDay;
+    date_normal_not_leap: err => "2003-02-29", OutOfRangeDay;
     date_normal_leap_year: ok => "2004-02-29", "2004-02-29";
-    date_special_100_not_leap: error => "1900-02-29", OutOfRangeDay;
+    date_special_100_not_leap: err => "1900-02-29", OutOfRangeDay;
     date_special_400_leap: ok => "2000-02-29", "2000-02-29";
 }
 
@@ -98,19 +98,19 @@ param_tests! {
     time_no_fraction: ok => "12:13:14", "12:13:14";
     time_fraction_small: ok => "12:13:14.123", "12:13:14.123";
     time_no_sec: ok => "12:13", "12:13:00";
-    time: error => "xxx", TooShort;
-    time: error => "xx:12", InvalidCharHour;
-    time_sep_hour: error => "12x12", InvalidCharTimeSep;
-    time: error => "12:x0", InvalidCharMinute;
-    time_sep_min: error => "12:13x", ExtraCharacters;
-    time: error => "12:13:x", InvalidCharSecond;
-    time: error => "12:13:12.", SecondFractionMissing;
-    time: error => "12:13:12.1234567", SecondFractionTooLong;
-    time: error => "24:00:00", OutOfRangeHour;
-    time: error => "23:60:00", OutOfRangeMinute;
-    time: error => "23:59:60", OutOfRangeSecond;
-    time_extra_x: error => "23:59:59xxx", ExtraCharacters;
-    time_extra_space: error => "23:59:59 ", ExtraCharacters;
+    time: err => "xxx", TooShort;
+    time: err => "xx:12", InvalidCharHour;
+    time_sep_hour: err => "12x12", InvalidCharTimeSep;
+    time: err => "12:x0", InvalidCharMinute;
+    time_sep_min: err => "12:13x", ExtraCharacters;
+    time: err => "12:13:x", InvalidCharSecond;
+    time: err => "12:13:12.", SecondFractionMissing;
+    time: err => "12:13:12.1234567", SecondFractionTooLong;
+    time: err => "24:00:00", OutOfRangeHour;
+    time: err => "23:60:00", OutOfRangeMinute;
+    time: err => "23:59:60", OutOfRangeSecond;
+    time_extra_x: err => "23:59:59xxx", ExtraCharacters;
+    time_extra_space: err => "23:59:59 ", ExtraCharacters;
 }
 
 #[test]
@@ -209,22 +209,22 @@ param_tests! {
     dt_seconds_fraction_break: ok => "2020-01-01 12:13:14.123z", "2020-01-01T12:13:14.123Z";
     dt_seconds_fraction_comma: ok => "2020-01-01 12:13:14,123z", "2020-01-01T12:13:14.123Z";
     dt_underscore: ok => "2020-01-01_12:13:14,123z", "2020-01-01T12:13:14.123Z";
-    dt_short_date: error => "xxx", TooShort;
-    dt_short_time: error => "2020-01-01T12:0", TooShort;
-    dt: error => "202x-01-01", InvalidCharYear;
-    dt: error => "2020-01-01x", InvalidCharDateTimeSep;
-    dt: error => "2020-01-01Txx:00", InvalidCharHour;
-    dt_1: error => "2020-01-01T12:00:00x", InvalidCharTzSign;
+    dt_short_date: err => "xxx", TooShort;
+    dt_short_time: err => "2020-01-01T12:0", TooShort;
+    dt: err => "202x-01-01", InvalidCharYear;
+    dt: err => "2020-01-01x", InvalidCharDateTimeSep;
+    dt: err => "2020-01-01Txx:00", InvalidCharHour;
+    dt_1: err => "2020-01-01T12:00:00x", InvalidCharTzSign;
     // same first byte as U+2212, different second b'\xe2\x89\x92'.decode()
-    dt_2: error => "2020-01-01T12:00:00≒", InvalidCharTzSign;
+    dt_2: err => "2020-01-01T12:00:00≒", InvalidCharTzSign;
     // same first and second bytes as U+2212, different third b'\xe2\x88\x93'.decode()
-    dt_3: error => "2020-01-01T12:00:00∓", InvalidCharTzSign;
-    dt: error => "2020-01-01T12:00:00+x", InvalidCharTzHour;
-    dt: error => "2020-01-01T12:00:00+00x", InvalidCharTzMinute;
-    dt_extra_space_z: error => "2020-01-01T12:00:00Z ", ExtraCharacters;
-    dt_extra_space_tz1: error => "2020-01-01T12:00:00+00:00 ", ExtraCharacters;
-    dt_extra_space_tz2: error => "2020-01-01T12:00:00+0000 ", ExtraCharacters;
-    dt_extra_xxx: error => "2020-01-01T12:00:00Zxxx", ExtraCharacters;
+    dt_3: err => "2020-01-01T12:00:00∓", InvalidCharTzSign;
+    dt: err => "2020-01-01T12:00:00+x", InvalidCharTzHour;
+    dt: err => "2020-01-01T12:00:00+00x", InvalidCharTzMinute;
+    dt_extra_space_z: err => "2020-01-01T12:00:00Z ", ExtraCharacters;
+    dt_extra_space_tz1: err => "2020-01-01T12:00:00+00:00 ", ExtraCharacters;
+    dt_extra_space_tz2: err => "2020-01-01T12:00:00+0000 ", ExtraCharacters;
+    dt_extra_xxx: err => "2020-01-01T12:00:00Zxxx", ExtraCharacters;
 }
 
 #[test]
@@ -271,36 +271,13 @@ fn duration_simple() {
     assert_eq!(d.to_string(), "P1Y");
 }
 
-#[test]
-fn duration_fractions() {
-    let d = Duration::parse_str("P1Y1DT2H0.5S").unwrap();
-    assert_eq!(
-        d,
-        Duration {
-            positive: true,
-            day: 366,
-            second: 7200,
-            microsecond: 500_000
-        }
-    );
-    assert_eq!(d.to_string(), "P1Y1DT7200.5S");
-    assert_eq!(
-        format!("{:?}", d),
-        "Duration { positive: true, day: 366, second: 7200, microsecond: 500000 }"
-    );
-}
-
-#[test]
-fn duration_1() {
-    let d = Duration::parse_str("P1DT1S").unwrap();
-    assert_eq!(
-        d,
-        Duration {
-            positive: true,
-            day: 1,
-            second: 1,
-            microsecond: 0
-        }
-    );
-    assert_eq!(d.to_string(), "P1DT1S");
+param_tests! {
+    Duration,
+    duration_simple: ok => "P1Y", "P1Y";
+    duration_simple_negative: ok => "-P1Y", "-P1Y";
+    duration_fraction: ok => "P1Y1DT2H0.5S", "P1Y1DT7200.5S";
+    duration_1: ok => "P1DT1S", "P1DT1S";
+    duration_time_42s: ok => "00:00:42", "PT42S";
+    duration_time_1h_2m_3s: ok => "01:02:03", "PT3723S";
+    duration_time_fraction: ok => "00:01:03.123", "PT63.123S";
 }

--- a/tests/main.rs
+++ b/tests/main.rs
@@ -335,6 +335,9 @@ fn duration_new_normalise() {
 
 param_tests! {
     Duration,
+    duration_too_short1: err => "", TooShort;
+    duration_too_short2: err => "+", TooShort;
+    duration_too_short3: err => "P", TooShort;
     duration_1y: ok => "P1Y", "P1Y";
     duration_123y: ok => "P123Y", "P123Y";
     duration_123_8y: ok => "P123.8Y", "P123Y292D";
@@ -348,10 +351,17 @@ param_tests! {
     duration_fraction1: ok => "PT0.555555S", "PT0.555555S";
     duration_fraction2: ok => "P1Y1DT2H0.5S", "P1Y1DT7200.5S";
     duration_1: ok => "P1DT1S", "P1DT1S";
+    duration: err => "PD", DurationInvalidNumber;
+    duration: err => "P1DT1MT1S", DurationTRepeated;
+    duration: err => "P1DT1.1M1S", DurationInvalidFraction;
+    duration: err => "P1DT1X", DurationInvalidTimeUnit;
+    duration_invalid_day_unit1: err => "P1X", DurationInvalidDateUnit;
+    duration_invalid_day_unit2: err => "P1", DurationInvalidDateUnit;
     duration_time_42s: ok => "00:00:42", "PT42S";
     duration_time_1m: ok => "00:01", "PT60S";
     duration_time_1h_2m_3s: ok => "01:02:03", "PT3723S";
     duration_time_fraction: ok => "00:01:03.123", "PT63.123S";
+    duration_time_extra: err => "00:01:03.123x", ExtraCharacters;
     duration_days_1day1: ok => "1 day", "P1D";
     duration_days_1day2: ok => "1day", "P1D";
     duration_days_1day3: ok => "1 day,", "P1D";
@@ -360,10 +370,19 @@ param_tests! {
     duration_days_1day6: ok => "1DAYS", "P1D";
     duration_days_1day7: ok => "1d", "P1D";
     duration_days_1day8: ok => "1d ", "P1D";
+    duration_days_invalid1: err => "1x", DurationInvalidDays;
+    duration_days_invalid2: err => "1dx", TooShort;
+    duration_days_invalid3: err => "1da", DurationInvalidDays;
+    duration_days_invalid4: err => "1", DurationInvalidDays;
+    duration_days_invalid5: err => "1 ", DurationInvalidDays;
+    duration_days_invalid6: err => "1 x", DurationInvalidDays;
     duration_days_neg: ok => "-1 day", "-P1D";
     duration_days_pos: ok => "+1 day", "P1D";
     duration_days_123days: ok => "123days", "P123D";
     duration_days_time: ok => "1 day 00:00:42", "P1DT42S";
     duration_days_time_neg: ok => "-1 day 00:00:42", "-P1DT42S";
     duration_exceeds_day: ok => "PT86500S", "P1DT100S";
+    duration_days_time_too_shoert: err => "1 day 00:", TooShort;
+    duration_days_time_wrong: err => "1 day 00:xx", InvalidCharMinute;
+    duration_days_time_extra: err => "1 day 00:00:00.123 ", ExtraCharacters;
 }

--- a/tests/main.rs
+++ b/tests/main.rs
@@ -1,7 +1,7 @@
 use std::fs::File;
 use std::io::Read;
 
-use not8601::{Date, DateTime, ParseError, Time};
+use not8601::{Date, DateTime, Duration, ParseError, Time};
 
 /// macro for expected ParseError errors
 macro_rules! expect_error {
@@ -336,4 +336,51 @@ fn test_rfc_3339_values_txt() {
         success += 1;
     }
     println!("{} formats successfully parsed", success);
+}
+
+#[test]
+fn duration_simple() {
+    let d = Duration::parse_str("P1Y").unwrap();
+    assert_eq!(
+        d,
+        Duration {
+            day: 365,
+            second: 0,
+            microsecond: 0
+        }
+    );
+    assert_eq!(d.to_string(), "P1Y");
+    assert_eq!(format!("{:?}", d), "Duration { day: 365, second: 0, microsecond: 0 }");
+}
+
+#[test]
+fn duration_fractions() {
+    let d = Duration::parse_str("P1Y1DT2H0.5S").unwrap();
+    assert_eq!(
+        d,
+        Duration {
+            day: 366,
+            second: 7200,
+            microsecond: 500_000
+        }
+    );
+    assert_eq!(d.to_string(), "P1Y1DT7200.5S");
+    assert_eq!(
+        format!("{:?}", d),
+        "Duration { day: 366, second: 7200, microsecond: 500000 }"
+    );
+}
+
+#[test]
+fn duration_1() {
+    let d = Duration::parse_str("P1DT1S").unwrap();
+    assert_eq!(
+        d,
+        Duration {
+            day: 1,
+            second: 1,
+            microsecond: 0
+        }
+    );
+    assert_eq!(d.to_string(), "P1DT1S");
 }

--- a/tests/main.rs
+++ b/tests/main.rs
@@ -344,13 +344,13 @@ fn duration_simple() {
     assert_eq!(
         d,
         Duration {
+            positive: true,
             day: 365,
             second: 0,
             microsecond: 0
         }
     );
     assert_eq!(d.to_string(), "P1Y");
-    assert_eq!(format!("{:?}", d), "Duration { day: 365, second: 0, microsecond: 0 }");
 }
 
 #[test]
@@ -359,6 +359,7 @@ fn duration_fractions() {
     assert_eq!(
         d,
         Duration {
+            positive: true,
             day: 366,
             second: 7200,
             microsecond: 500_000
@@ -367,7 +368,7 @@ fn duration_fractions() {
     assert_eq!(d.to_string(), "P1Y1DT7200.5S");
     assert_eq!(
         format!("{:?}", d),
-        "Duration { day: 366, second: 7200, microsecond: 500000 }"
+        "Duration { positive: true, day: 366, second: 7200, microsecond: 500000 }"
     );
 }
 
@@ -377,6 +378,7 @@ fn duration_1() {
     assert_eq!(
         d,
         Duration {
+            positive: true,
             day: 1,
             second: 1,
             microsecond: 0

--- a/tests/main.rs
+++ b/tests/main.rs
@@ -351,6 +351,7 @@ param_tests! {
     duration_fraction1: ok => "PT0.555555S", "PT0.555555S";
     duration_fraction2: ok => "P1Y1DT2H0.5S", "P1Y1DT7200.5S";
     duration_1: ok => "P1DT1S", "P1DT1S";
+    duration_all: ok => "P1Y2M3DT4H5M6S", "P1Y63DT14706S";
     duration: err => "PD", DurationInvalidNumber;
     duration: err => "P1DT1MT1S", DurationTRepeated;
     duration: err => "P1DT1.1M1S", DurationInvalidFraction;

--- a/tests/main.rs
+++ b/tests/main.rs
@@ -271,13 +271,99 @@ fn duration_simple() {
     assert_eq!(d.to_string(), "P1Y");
 }
 
+#[test]
+fn duration_total_seconds() {
+    let d = Duration::parse_str("P1MT1.5S").unwrap();
+    assert_eq!(
+        d,
+        Duration {
+            positive: true,
+            day: 30,
+            second: 1,
+            microsecond: 500_000
+        }
+    );
+    assert_eq!(d.to_string(), "P30DT1.5S");
+    assert_eq!(d.signed_total_seconds(), 30 * 86_400 + 1);
+    assert_eq!(d.signed_microseconds(), 500_000);
+}
+
+#[test]
+fn duration_total_seconds_neg() {
+    let d = Duration::parse_str("-P1DT42.123456S").unwrap();
+    assert_eq!(
+        d,
+        Duration {
+            positive: false,
+            day: 1,
+            second: 42,
+            microsecond: 123_456
+        }
+    );
+    assert_eq!(d.to_string(), "-P1DT42.123456S");
+    assert_eq!(d.signed_total_seconds(), -86_442);
+    assert_eq!(d.signed_microseconds(), -123_456);
+}
+
+#[test]
+fn duration_fractions() {
+    let d = Duration::parse_str("P1.123W").unwrap();
+    assert_eq!(
+        d,
+        Duration {
+            positive: true,
+            day: 7,
+            second: 74390,
+            microsecond: 400_000
+        }
+    );
+}
+
+#[test]
+fn duration_new_normalise() {
+    let d = Duration::new(false, 1, 86500, 1_000_123);
+    assert_eq!(
+        d,
+        Duration {
+            positive: false,
+            day: 2,
+            second: 101,
+            microsecond: 123,
+        }
+    );
+}
+
 param_tests! {
     Duration,
-    duration_simple: ok => "P1Y", "P1Y";
+    duration_1y: ok => "P1Y", "P1Y";
+    duration_123y: ok => "P123Y", "P123Y";
+    duration_123_8y: ok => "P123.8Y", "P123Y292D";
+    duration_1m: ok => "P1M", "P30D";
+    duration_1_5m: ok => "P1.5M", "P45D";
+    duration_1w: ok => "P1W", "P7D";
+    duration_1_1w: ok => "P1.1W", "P7DT60480S";
+    duration_1_123w: ok => "P1.123W", "P7DT74390.4S";
     duration_simple_negative: ok => "-P1Y", "-P1Y";
-    duration_fraction: ok => "P1Y1DT2H0.5S", "P1Y1DT7200.5S";
+    duration_simple_positive: ok => "+P1Y", "P1Y";
+    duration_fraction1: ok => "PT0.555555S", "PT0.555555S";
+    duration_fraction2: ok => "P1Y1DT2H0.5S", "P1Y1DT7200.5S";
     duration_1: ok => "P1DT1S", "P1DT1S";
     duration_time_42s: ok => "00:00:42", "PT42S";
+    duration_time_1m: ok => "00:01", "PT60S";
     duration_time_1h_2m_3s: ok => "01:02:03", "PT3723S";
     duration_time_fraction: ok => "00:01:03.123", "PT63.123S";
+    duration_days_1day1: ok => "1 day", "P1D";
+    duration_days_1day2: ok => "1day", "P1D";
+    duration_days_1day3: ok => "1 day,", "P1D";
+    duration_days_1day4: ok => "1 day, ", "P1D";
+    duration_days_1day5: ok => "1days", "P1D";
+    duration_days_1day6: ok => "1DAYS", "P1D";
+    duration_days_1day7: ok => "1d", "P1D";
+    duration_days_1day8: ok => "1d ", "P1D";
+    duration_days_neg: ok => "-1 day", "-P1D";
+    duration_days_pos: ok => "+1 day", "P1D";
+    duration_days_123days: ok => "123days", "P123D";
+    duration_days_time: ok => "1 day 00:00:42", "P1DT42S";
+    duration_days_time_neg: ok => "-1 day 00:00:42", "-P1DT42S";
+    duration_exceeds_day: ok => "PT86500S", "P1DT100S";
 }


### PR DESCRIPTION
Add the following datetime formats:
* ISO8601, e.g `P1Y2M3DT4H5M6S`
* time formats, e.g. `12:13:14.56`
* time formats prefixed with day(s), e.g. `2 days 12:13:14`