### PR TITLE
Catch large durations

### DIFF
--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -107,7 +107,7 @@ checksum = "f2cc38e8fa666e2de3c4aba7edeb5ffc5246c1c2ed0e3d17e560aeeba736b23f"
 
 [[package]]
 name = "speedate"
-version = "0.3.0"
+version = "0.4.1"
 dependencies = [
  "strum",
  "strum_macros",

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -28,3 +28,9 @@ name = "datetime_parse_bytes"
 path = "fuzz_targets/datetime_parse_bytes.rs"
 test = false
 doc = false
+
+[[bin]]
+name = "duration_parse_bytes"
+path = "fuzz_targets/duration_parse_bytes.rs"
+test = false
+doc = false

--- a/fuzz/fuzz_targets/duration_parse_bytes.rs
+++ b/fuzz/fuzz_targets/duration_parse_bytes.rs
@@ -1,0 +1,10 @@
+#![no_main]
+use libfuzzer_sys::fuzz_target;
+use speedate::Duration;
+
+fuzz_target!(|data: &[u8]| {
+    match Duration::parse_bytes(data) {
+        Ok(_) => (),
+        Err(_) => (),
+    }
+});

--- a/src/duration.rs
+++ b/src/duration.rs
@@ -275,9 +275,8 @@ impl Duration {
                             let extra_seconds = fraction * mult as f64;
                             let extra_full_seconds = extra_seconds.trunc();
                             second = checked!(second + extra_full_seconds as u32);
-                            microsecond = checked!(
-                                microsecond + ((extra_seconds - extra_full_seconds) * 1_000_000.0).round() as u32
-                            );
+                            let micro_extra = ((extra_seconds - extra_full_seconds) * 1_000_000.0).round() as u32;
+                            microsecond = checked!(microsecond + micro_extra);
                         }
                     } else {
                         let mult: u64 = match bytes.get(position).copied() {

--- a/src/duration.rs
+++ b/src/duration.rs
@@ -94,6 +94,9 @@ impl fmt::Display for Duration {
     }
 }
 
+// so that after multiplying by 10 and adding the current digit, the value cannot overflow
+const U64_LIMIT: u64 = u64::MAX;
+
 impl Duration {
     /// Create a duration from raw values.
     ///
@@ -410,6 +413,9 @@ impl Duration {
                 Some(c) if (b'0'..=b'9').contains(c) => {
                     value *= 10;
                     value += (c - b'0') as u64;
+                    if value >= U64_LIMIT {
+                        return Err(ParseError::DurationInvalidNumber)
+                    }
                     position += 1;
                 }
                 _ => return Ok((value, position)),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -121,6 +121,8 @@ pub enum ParseError {
     DurationInvalidDateUnit,
     /// "day" identifier in duration not correctly formatted
     DurationInvalidDays,
+    /// a numeric value in the duration is too large
+    DurationValueTooLarge,
     /// dates before 1600 are not supported as unix timestamps
     DateTooSmall,
     /// dates after 9999 are not supported as unix timestamps

--- a/tests/main.rs
+++ b/tests/main.rs
@@ -845,12 +845,7 @@ fn duration_comparison() {
 
 #[test]
 fn duration_new_err() {
-    let d = Duration::new(
-	    true,
-	    18446744073709551615,
-	    4294967295,
-	    905969663,
-	);
+    let d = Duration::new(true, 18446744073709551615, 4294967295, 905969663);
     match d {
         Ok(t) => panic!("unexpectedly valid: {:?}", t),
         Err(e) => assert_eq!(e, ParseError::DurationValueTooLarge),

--- a/tests/main.rs
+++ b/tests/main.rs
@@ -897,4 +897,16 @@ param_tests! {
     duration_days_time_too_shoert: err => "1 day 00:", TooShort;
     duration_days_time_wrong: err => "1 day 00:xx", InvalidCharMinute;
     duration_days_time_extra: err => "1 day 00:00:00.123 ", ExtraCharacters;
+    duration_overflow: err => "18446744073709551616 day 12:00", DurationInvalidNumber;
+}
+
+#[test]
+fn duration_large() {
+    let d = Duration::parse_str(&format!("{} day 00:00", u64::MAX - 1)).unwrap();
+    assert_eq!(d.to_string(), "P50539024859478223Y219D");
+
+    match Duration::parse_str(&format!("{} day 00:00", u64::MAX)) {
+        Ok(dur_string) => panic!("unexpected ok: {:?}", dur_string),
+        Err(e) => assert_eq!(e, ParseError::DurationInvalidNumber),
+    }
 }

--- a/tests/main.rs
+++ b/tests/main.rs
@@ -794,7 +794,7 @@ fn duration_fractions() {
 
 #[test]
 fn duration_new_normalise() {
-    let d = Duration::new(false, 1, 86500, 1_000_123);
+    let d = Duration::new(false, 1, 86500, 1_000_123).unwrap();
     assert_eq!(
         d,
         Duration {
@@ -808,7 +808,7 @@ fn duration_new_normalise() {
 
 #[test]
 fn duration_new_normalise2() {
-    let d = Duration::new(true, 0, 0, 1_000_000);
+    let d = Duration::new(true, 0, 0, 1_000_000).unwrap();
     assert_eq!(
         d,
         Duration {
@@ -822,8 +822,8 @@ fn duration_new_normalise2() {
 
 #[test]
 fn duration_comparison() {
-    let d1 = Duration::new(true, 0, 0, 1_000_000);
-    let d2 = Duration::new(true, 0, 0, 1_000_001);
+    let d1 = Duration::new(true, 0, 0, 1_000_000).unwrap();
+    let d2 = Duration::new(true, 0, 0, 1_000_001).unwrap();
     assert!(d1 < d2);
     assert!(d1 <= d2);
     assert!(d1 <= d1.clone());
@@ -831,8 +831,8 @@ fn duration_comparison() {
     assert!(d2 >= d1);
     assert!(d2 >= d2.clone());
 
-    let d3 = Duration::new(true, 3, 0, 0);
-    let d4 = Duration::new(false, 4, 0, 0);
+    let d3 = Duration::new(true, 3, 0, 0).unwrap();
+    let d4 = Duration::new(false, 4, 0, 0).unwrap();
     assert!(d3 > d4);
     assert!(d3 >= d4);
     assert!(d4 < d3);
@@ -841,6 +841,20 @@ fn duration_comparison() {
     let d5 = Duration::parse_str("+P1D").unwrap();
     let d6 = Duration::parse_str("-P2D").unwrap();
     assert!(d5 > d6);
+}
+
+#[test]
+fn duration_new_err() {
+    let d = Duration::new(
+	    true,
+	    18446744073709551615,
+	    4294967295,
+	    905969663,
+	);
+    match d {
+        Ok(t) => panic!("unexpectedly valid: {:?}", t),
+        Err(e) => assert_eq!(e, ParseError::DurationValueTooLarge),
+    }
 }
 
 param_tests! {
@@ -898,6 +912,7 @@ param_tests! {
     duration_days_time_wrong: err => "1 day 00:xx", InvalidCharMinute;
     duration_days_time_extra: err => "1 day 00:00:00.123 ", ExtraCharacters;
     duration_overflow: err => "18446744073709551616 day 12:00", DurationValueTooLarge;
+    duration_fuzz1: err => "P18446744073709551611DT8031M1M1M1M", DurationValueTooLarge;
 }
 
 #[test]

--- a/tests/main.rs
+++ b/tests/main.rs
@@ -897,16 +897,17 @@ param_tests! {
     duration_days_time_too_shoert: err => "1 day 00:", TooShort;
     duration_days_time_wrong: err => "1 day 00:xx", InvalidCharMinute;
     duration_days_time_extra: err => "1 day 00:00:00.123 ", ExtraCharacters;
-    duration_overflow: err => "18446744073709551616 day 12:00", DurationInvalidNumber;
+    duration_overflow: err => "18446744073709551616 day 12:00", DurationValueTooLarge;
 }
 
 #[test]
 fn duration_large() {
-    let d = Duration::parse_str(&format!("{} day 00:00", u64::MAX - 1)).unwrap();
-    assert_eq!(d.to_string(), "P50539024859478223Y219D");
+    let d = Duration::parse_str(&format!("{} day 00:00", u64::MAX)).unwrap();
+    assert_eq!(d.to_string(), "P50539024859478223Y220D");
 
-    match Duration::parse_str(&format!("{} day 00:00", u64::MAX)) {
-        Ok(dur_string) => panic!("unexpected ok: {:?}", dur_string),
-        Err(e) => assert_eq!(e, ParseError::DurationInvalidNumber),
+    let input = format!("{}1 day 00:00", u64::MAX);
+    match Duration::parse_str(&input) {
+        Ok(t) => panic!("unexpectedly valid: {:?} -> {:?}", input, t),
+        Err(e) => assert_eq!(e, ParseError::DurationValueTooLarge),
     }
 }


### PR DESCRIPTION
duration parsing was overflowing in a number of places before this.